### PR TITLE
Preference Storage Optimizations

### DIFF
--- a/filepicker-library/src/io/filepicker/utils/PreferencesUtils.java
+++ b/filepicker-library/src/io/filepicker/utils/PreferencesUtils.java
@@ -53,7 +53,10 @@ public final class PreferencesUtils {
 
     // String
     private void setStringValue(String key, String value){
-        getSharedPreferences().edit().putString(key, value).apply();
+        if (value != null)
+            getSharedPreferences().edit().putString(key, value).apply();
+        else
+            getSharedPreferences().edit().remove(key).apply();
     }
 
     private String getStringValue(String key){


### PR DESCRIPTION
While I was going through the [doc](https://developer.android.com/reference/android/content/SharedPreferences.Editor.html), I figured out that `remove` is a better option instead of writing a null value to a `preference`. And theoretically as well, `remove` will clear the `key` & `value`. Hence, will let the app consume less memory, wherever possible. 