### PR TITLE
fix issue #95 https://github.com/Ink/filepicker-android/issues/95

### DIFF
--- a/filepicker-library/src/io/filepicker/utils/FilesUtils.java
+++ b/filepicker-library/src/io/filepicker/utils/FilesUtils.java
@@ -44,8 +44,36 @@ public class FilesUtils {
 
         String path = getPath(context, uri);
         // File path and mimetype are required
-        if(path == null)
+        if(path == null) {
+            InputStream in = null;
+            try {
+                in = context.getContentResolver().openInputStream(uri);
+            } catch (FileNotFoundException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+
+            Bitmap bitmap = BitmapFactory.decodeStream(in);
+            if (bitmap != null){
+                File file = new File(context.getCacheDir(), "image");
+                try {
+                    OutputStream os = new BufferedOutputStream(new FileOutputStream(file));
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, os);
+                    os.close();
+                }
+                catch (FileNotFoundException e){
+                    e.printStackTrace();
+                }
+                catch (IOException e){
+                    e.printStackTrace();
+                }
+
+                return new TypedFile(mimetype, file);
+            }
+
             return null;
+        }
 
         File file = new File(path);
 


### PR DESCRIPTION
According to the issue I reported recently https://github.com/Ink/filepicker-android/issues/95 there is a bug when trying to get an image from the gallery but that is in reality fetched from Google Drive. This is a work around to fix the bug